### PR TITLE
Bump pillow from 11.2.1 to 11.3.0 in the pip group

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ motor
 nekosbest
 numpy
 opencv-python
-pillow==11.2.1
+pillow==11.3.0
 psutil
 ntgcalls==2.0.5
 py-tgcalls==2.2.5


### PR DESCRIPTION
Bumps the pip group with 1 update: [pillow](https://github.com/python-pillow/Pillow).


Updates `pillow` from 11.2.1 to 11.3.0
- [Release notes](https://github.com/python-pillow/Pillow/releases)
- [Changelog](https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst)
- [Commits](https://github.com/python-pillow/Pillow/compare/11.2.1...11.3.0)

---
updated-dependencies:
- dependency-name: pillow dependency-version: 11.3.0 dependency-type: direct:production dependency-group: pip ...